### PR TITLE
Merge Cheaty and Morpheus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,8 +2,8 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>tc.oc.occ</groupId>
     <artifactId>Cheaty</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
-    <name>Bolty</name>
+    <version>1.2.0-SNAPSHOT</version>
+    <name>Cheaty</name>
     <description>A minecraft to discord java plugin for anti-cheat logging</description>
 
 
@@ -69,14 +69,6 @@
             <version>2.6.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
-        <!-- Morpheus - https://github.com/OvercastCommunity/Morpheus -->
-        <dependency>
-            <groupId>oc.tc</groupId>
-            <artifactId>Morpheus</artifactId>
-            <version>1.0.1-SNAPSHOT</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -126,23 +118,23 @@
                     <relocations>
                         <relocation>
                             <pattern>co.aikar.commands</pattern>
-                            <shadedPattern>tc.oc.occ.bolt.lib.acf</shadedPattern>
+                            <shadedPattern>tc.oc.occ.cheaty.lib.acf</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>org.apache.logging.log4j</pattern>
-                            <shadedPattern>tc.oc.occ.bolt.lib.logger</shadedPattern>
+                            <shadedPattern>tc.oc.occ.cheaty.lib.logger</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>okhttp3</pattern>
-                            <shadedPattern>tc.oc.occ.bolt.lib.okhttp3</shadedPattern>
+                            <shadedPattern>tc.oc.occ.cheaty.lib.okhttp3</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>okio</pattern>
-                            <shadedPattern>tc.oc.occ.bolt.lib.okio</shadedPattern>
+                            <shadedPattern>tc.oc.occ.cheaty.lib.okio</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>com.fasterxml</pattern>
-                            <shadedPattern>tc.oc.occ.bolt.lib.jackson</shadedPattern>
+                            <shadedPattern>tc.oc.occ.cheaty.lib.jackson</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/src/main/java/tc/oc/occ/cheaty/BotConfig.java
+++ b/src/main/java/tc/oc/occ/cheaty/BotConfig.java
@@ -1,5 +1,7 @@
 package tc.oc.occ.cheaty;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.configuration.Configuration;
 
 public class BotConfig {
@@ -24,6 +26,10 @@ public class BotConfig {
 
   private String reportChannel;
   private String cheatChannel;
+
+  private boolean morpheusEnabled;
+  private String morpheusPermission;
+  private Component morpheusPrefix;
 
   public BotConfig(Configuration config) {
     reload(config);
@@ -51,6 +57,12 @@ public class BotConfig {
 
     this.reportChannel = config.getString("channels.reports");
     this.cheatChannel = config.getString("channels.anticheat");
+
+    this.morpheusEnabled = config.getBoolean("morpheus.enabled");
+    this.morpheusPermission = config.getString("morpheus.permission-node");
+    this.morpheusPrefix =
+        LegacyComponentSerializer.legacyAmpersand()
+            .deserialize(config.getString("morpheus.alert-prefix"));
   }
 
   public boolean isEnabled() {
@@ -111,5 +123,17 @@ public class BotConfig {
 
   public String getAntiCheatChannel() {
     return cheatChannel;
+  }
+
+  public boolean isMorpheusEnabled() {
+    return morpheusEnabled;
+  }
+
+  public String getMorpheusPermission() {
+    return morpheusPermission;
+  }
+
+  public Component getMorpheusPrefix() {
+    return morpheusPrefix;
   }
 }

--- a/src/main/java/tc/oc/occ/cheaty/BotListener.java
+++ b/src/main/java/tc/oc/occ/cheaty/BotListener.java
@@ -4,7 +4,6 @@ import dev.pgm.community.events.PlayerReportEvent;
 import net.climaxmc.autokiller.events.AutoKillCheatEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import tc.oc.morpheus.NotifyCommandEvent;
 import tc.oc.occ.cheaty.DiscordBot.RelayType;
 
 public class BotListener implements Listener {
@@ -25,10 +24,5 @@ public class BotListener implements Listener {
   @EventHandler
   public void onAutoKillerViolation(AutoKillCheatEvent event) {
     bot.sendRelay(event.getAlert(), RelayType.AUTOKILL);
-  }
-
-  @EventHandler
-  public void onMorpheusNotify(NotifyCommandEvent event) {
-    bot.sendRelay(event.getCommand(), RelayType.MATRIX);
   }
 }

--- a/src/main/java/tc/oc/occ/cheaty/Cheaty.java
+++ b/src/main/java/tc/oc/occ/cheaty/Cheaty.java
@@ -4,6 +4,7 @@ import co.aikar.commands.BukkitCommandManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import tc.oc.occ.cheaty.commands.AdminCommands;
 import tc.oc.occ.cheaty.commands.BotCommands;
+import tc.oc.occ.cheaty.commands.MorpheusCommands;
 
 public class Cheaty extends JavaPlugin {
 
@@ -34,6 +35,7 @@ public class Cheaty extends JavaPlugin {
     commands.registerDependency(BotConfig.class, config);
     commands.registerCommand(new BotCommands());
     commands.registerCommand(new AdminCommands());
+    commands.registerCommand(new MorpheusCommands());
   }
 
   private void registerListeners() {

--- a/src/main/java/tc/oc/occ/cheaty/commands/MorpheusCommands.java
+++ b/src/main/java/tc/oc/occ/cheaty/commands/MorpheusCommands.java
@@ -1,0 +1,78 @@
+package tc.oc.occ.cheaty.commands;
+
+import static net.kyori.adventure.text.Component.space;
+import static net.kyori.adventure.text.Component.text;
+
+import co.aikar.commands.BaseCommand;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Dependency;
+import co.aikar.commands.annotation.Syntax;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import tc.oc.occ.cheaty.BotConfig;
+import tc.oc.occ.cheaty.DiscordBot;
+import tc.oc.occ.cheaty.DiscordBot.RelayType;
+import tc.oc.pgm.api.PGM;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.util.Audience;
+import tc.oc.pgm.util.named.NameStyle;
+import tc.oc.pgm.util.text.TextTranslations;
+
+public class MorpheusCommands extends BaseCommand {
+
+  @Dependency private BotConfig config;
+  @Dependency private DiscordBot bot;
+
+  @CommandAlias("morpheus")
+  @Syntax("[player] [message]")
+  @CommandPermission("morpheus.notify")
+  public void notify(CommandSender sender, String target, String message) {
+
+    if (!config.isMorpheusEnabled()) {
+      sender.sendMessage(ChatColor.RED + "Morpheus alerts are not enabled - Check the config.yml");
+      return;
+    }
+
+    Component formattedTrigger = text(target, NamedTextColor.DARK_AQUA);
+
+    Player player = Bukkit.getPlayer(target);
+    Match match = PGM.get().getMatchManager().getMatch(player);
+    MatchPlayer matchPlayer = match != null ? match.getPlayer(player) : null;
+
+    if (matchPlayer != null) {
+      formattedTrigger = matchPlayer.getName(NameStyle.VERBOSE);
+    }
+
+    // Create component from formatted '&' string
+    TextComponent notification = LegacyComponentSerializer.legacyAmpersand().deserialize(message);
+
+    Component formatted =
+        text()
+            .append(config.getMorpheusPrefix())
+            .append(space())
+            .append(formattedTrigger)
+            .append(space())
+            .append(notification)
+            .build();
+
+    Bukkit.getOnlinePlayers().stream()
+        .filter(user -> user.hasPermission(config.getMorpheusPermission()))
+        .map(Audience::get)
+        .forEach(viewer -> viewer.sendMessage(formatted));
+
+    Audience.get(Bukkit.getConsoleSender()).sendMessage(formatted);
+
+    // Replace '§' chars with '&' as translate legacy uses these
+    String legacyString = TextTranslations.translateLegacy(formatted).replace('§', '&');
+
+    bot.sendRelay(legacyString, RelayType.MATRIX);
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -38,3 +38,12 @@ prefix:
   matrix: ":warning: "
   command: ""
   
+# Morpheus - Enables clickable and visually enhanced notifications for matric violations.
+morpheus:
+  enabled: true
+  # Permission node requred for viewing altered notifications
+  permission-node: matrix.notify
+  # Alert prefix used to format notifications
+  alert-prefix: "&f[&6AC&f]"
+  
+  


### PR DESCRIPTION
This PR merges the capabilities of the [Morpheus](https://github.com/OvercastCommunity/Morpheus) plugin into Cheaty. Morpheus allowed for matrix notifications sent to be clickable. Thanks to the work done by @Pugzy previously, this logic will now sit in Cheaty so we have an all-in-one plugin for anti-cheat notifications. 