### PR TITLE
Add discord role ping when no staff are active

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
             <version>2.6.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>tc.oc.occ</groupId>
+            <artifactId>Idly</artifactId>
+            <version>1.1.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/tc/oc/occ/cheaty/BotConfig.java
+++ b/src/main/java/tc/oc/occ/cheaty/BotConfig.java
@@ -1,5 +1,6 @@
 package tc.oc.occ.cheaty;
 
+import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.configuration.Configuration;
@@ -30,6 +31,15 @@ public class BotConfig {
   private boolean morpheusEnabled;
   private String morpheusPermission;
   private Component morpheusPrefix;
+
+  private boolean pingsEnabled;
+  private int reportThreshold;
+  private int reportWindow;
+  private int staffIdleTime;
+  private List<String> pingDiscordRoles;
+
+  private String staffPermissionNode;
+  private String offDutyPermissionNode;
 
   public BotConfig(Configuration config) {
     reload(config);
@@ -63,6 +73,14 @@ public class BotConfig {
     this.morpheusPrefix =
         LegacyComponentSerializer.legacyAmpersand()
             .deserialize(config.getString("morpheus.alert-prefix"));
+
+    this.pingsEnabled = config.getBoolean("pings.enabled");
+    this.reportThreshold = config.getInt("pings.report-threshold");
+    this.reportWindow = config.getInt("pings.report-window");
+    this.staffIdleTime = config.getInt("pings.staff-idle-time");
+    this.pingDiscordRoles = config.getStringList("pings.discord-roles");
+    this.staffPermissionNode = config.getString("staff-permission");
+    this.offDutyPermissionNode = config.getString("off-duty-permission");
   }
 
   public boolean isEnabled() {
@@ -135,5 +153,33 @@ public class BotConfig {
 
   public Component getMorpheusPrefix() {
     return morpheusPrefix;
+  }
+
+  public boolean isPingEnabled() {
+    return pingsEnabled;
+  }
+
+  public int getReportThreshold() {
+    return reportThreshold;
+  }
+
+  public int getReportWindowMinutes() {
+    return reportWindow;
+  }
+
+  public int getStaffIdleMinutes() {
+    return staffIdleTime;
+  }
+
+  public List<String> getDiscordPingRoles() {
+    return pingDiscordRoles;
+  }
+
+  public String getStaffPermission() {
+    return staffPermissionNode;
+  }
+
+  public String getOffDutyPermission() {
+    return offDutyPermissionNode;
   }
 }

--- a/src/main/java/tc/oc/occ/cheaty/PingMonitor.java
+++ b/src/main/java/tc/oc/occ/cheaty/PingMonitor.java
@@ -1,0 +1,81 @@
+package tc.oc.occ.cheaty;
+
+import dev.pgm.community.assistance.Report;
+import dev.pgm.community.events.PlayerReportEvent;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import tc.oc.occ.idly.Idly;
+
+public class PingMonitor {
+
+  private Map<UUID, Map<UUID, Long>> reportsByPlayer = new HashMap<>();
+
+  private final BotConfig config;
+  private final DiscordBot discord;
+
+  public PingMonitor(BotConfig config, DiscordBot discord) {
+    this.config = config;
+    this.discord = discord;
+  }
+
+  private boolean isNotIdle(Player player) {
+    Idly idlyPlugin = Idly.get();
+    if (idlyPlugin == null) {
+      return true;
+    }
+
+    return !idlyPlugin.getIdlyManager().isIdle(player, config.getStaffIdleMinutes() * 60);
+  }
+
+  private boolean isStaffOnline() {
+    List<Player> staff =
+        Bukkit.getOnlinePlayers().stream()
+            .filter(p -> p.hasPermission(config.getStaffPermission()))
+            .filter(p -> !p.hasPermission(config.getOffDutyPermission()))
+            .filter(p -> isNotIdle(p))
+            .collect(Collectors.toList());
+
+    return !staff.isEmpty();
+  }
+
+  public void onReport(PlayerReportEvent event) {
+    if (isStaffOnline()) return; // Don't log when staff are online and active
+
+    Report report = event.getReport();
+    UUID reportedId = report.getTargetId();
+    UUID reporterId = report.getSenderId();
+    long reportTime = System.currentTimeMillis();
+
+    Map<UUID, Long> reports = reportsByPlayer.get(reportedId);
+    if (reports == null) {
+      reports = new HashMap<>();
+      reportsByPlayer.put(reportedId, reports);
+    }
+
+    reports.put(reporterId, reportTime);
+
+    checkReports(report, reportedId, reportTime);
+  }
+
+  private void checkReports(Report report, UUID reportedId, long reportTime) {
+    Map<UUID, Long> reports = reportsByPlayer.get(reportedId);
+    if (reports != null) {
+      int numReports = 0;
+      for (long time : reports.values()) {
+        if ((reportTime - time) <= (config.getReportWindowMinutes() * 60 * 1000)) {
+          numReports++;
+        }
+      }
+
+      if (numReports >= config.getReportThreshold()) {
+        discord.sendReportPing(report, numReports);
+        reportsByPlayer.remove(reportedId); // remove the reports after the ping is sent
+      }
+    }
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,7 +4,13 @@ token: "" # Discord bot token
 server: "" # ID of discord server
 
 # Minecraft server display-name
-server-name: "occ" # Server name
+server-name: "" # Server name
+
+# Permission used to identify staff members
+staff-permission: "cheaty.staff"
+
+# Permission used to identify off-duty staff members
+off-duty-permission: "cheaty.off-duty"
 
 channels:
   reports: "" # ID of channel where reports are sent
@@ -22,7 +28,7 @@ types:
 # %reporter% - Player who issued report
 # %reported% - Player who has been reported
 # %reason%   - Reason for report
-report-format: "[%server%] **%reporter% reported %reported%: %reason%**"
+report-format: "[%server%] **`%reporter%` reported `%reported%`: %reason%**"
 
 # Relay - Command based (Used for AutoKiller and via /relay)
 #
@@ -46,4 +52,15 @@ morpheus:
   # Alert prefix used to format notifications
   alert-prefix: "&f[&6AC&f]"
   
-  
+# Pings
+pings:
+  enabled: true
+  # The number of unique reports required within the report window to trigger a ping
+  report-threshold: 3
+  # The time period during which reports will be counted
+  report-window: 30 # Minutes
+  # The time period in minutes after which staff should be considered idle
+  staff-idle-time: 10 # Minutes
+  # The roles to be pinged when the report threshold is reached
+  discord-roles:
+    - "" # <use discord group ids>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,4 +3,4 @@ main: tc.oc.occ.cheaty.Cheaty
 description: A minecraft to discord bot
 version: ${project.version}
 author: applenick
-softdepend: [PGM, AutoKiller, Morpheus]
+softdepend: [PGM, AutoKiller, Idly]


### PR DESCRIPTION
This PR adds a new feature that allows pinging a set of Discord roles when a configurable number of reports for a single player are submitted and no staff members are online. The plugin takes into account when staff members are idle based on some new changes to the [Idly](https://github.com/OvercastCommunity/Idly) plugin.