### PR TITLE
Fix commands with alias and subcommands

### DIFF
--- a/src/main/java/tc/oc/occ/cheaty/commands/AdminCommands.java
+++ b/src/main/java/tc/oc/occ/cheaty/commands/AdminCommands.java
@@ -5,15 +5,17 @@ import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Dependency;
 import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Subcommand;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import tc.oc.occ.cheaty.Cheaty;
 
+@CommandAlias("cheaty")
 public class AdminCommands extends BaseCommand {
 
   @Dependency private Cheaty plugin;
 
-  @CommandAlias("cheaty")
+  @Subcommand("reload")
   @Description("Reload cheaty config")
   @CommandPermission("cheaty.admin")
   public void reload(CommandSender sender) {

--- a/src/main/java/tc/oc/occ/cheaty/commands/BotCommands.java
+++ b/src/main/java/tc/oc/occ/cheaty/commands/BotCommands.java
@@ -4,16 +4,18 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Dependency;
+import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import org.bukkit.command.CommandSender;
 import tc.oc.occ.cheaty.DiscordBot;
 import tc.oc.occ.cheaty.DiscordBot.RelayType;
 
+@CommandAlias("cheaty")
 public class BotCommands extends BaseCommand {
 
   @Dependency private DiscordBot bot;
 
-  @CommandAlias("relay")
+  @Subcommand("relay")
   @Syntax("[message] - Message to relay to discord")
   @CommandPermission("cheaty.bot")
   public void relay(CommandSender sender, String message) {

--- a/src/main/java/tc/oc/occ/cheaty/commands/CheatNotifyCommand.java
+++ b/src/main/java/tc/oc/occ/cheaty/commands/CheatNotifyCommand.java
@@ -7,6 +7,7 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Dependency;
+import co.aikar.commands.annotation.Subcommand;
 import co.aikar.commands.annotation.Syntax;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
@@ -26,12 +27,13 @@ import tc.oc.pgm.util.Audience;
 import tc.oc.pgm.util.named.NameStyle;
 import tc.oc.pgm.util.text.TextTranslations;
 
+@CommandAlias("cheaty")
 public class CheatNotifyCommand extends BaseCommand {
 
   @Dependency private BotConfig config;
   @Dependency private DiscordBot bot;
 
-  @CommandAlias("cheaty notify")
+  @Subcommand("notify")
   @Syntax("[player] [message]")
   @CommandPermission("cheaty.notify")
   public void notify(CommandSender sender, String target, String message) {


### PR DESCRIPTION
Registers the commands as:
- `cheaty reload`
- `cheaty notify`
- `cheaty relay`