### PR TITLE
Escape Markdown characters in relay messages

### DIFF
--- a/src/main/java/tc/oc/occ/cheaty/DiscordBot.java
+++ b/src/main/java/tc/oc/occ/cheaty/DiscordBot.java
@@ -137,13 +137,23 @@ public class DiscordBot {
 
   public void sendRelay(String message, RelayType type) {
     if (!config.isRelayCommandEnabled()) return;
-    String formatted = config.getRelayFormat().replace("%message%", message);
+    String formatted =
+        config
+            .getRelayFormat()
+            .replace("%message%", message)
+            .replace("_", "\\_")
+            .replace("*", "\\*");
     sendMessage(getPrefix(type) + formatted, false);
   }
 
   public void sendAutoKiller(AutoKillCheatEvent event) {
     if (!config.isAutoKillerEnabled()) return;
-    String formatted = config.getRelayFormat().replace("%message%", event.getAlert());
+    String formatted =
+        config
+            .getRelayFormat()
+            .replace("%message%", event.getAlert())
+            .replace("_", "\\_")
+            .replace("*", "\\*");
     sendMessage(getPrefix(RelayType.AUTOKILL) + formatted, false);
   }
 


### PR DESCRIPTION
Two or more underscores on a player's name could make their name appear incorrectly in anticheat relay messages, as it could make parts of their name _italic_

(for instance, currently if someone called `_applenick_` triggers an anticheat alert it appears as _applenick_ on Discord)

Also escapes asterisks, which would behave in a similar way if a player had a lot of ranks that used * as suffixes/prefixes

Tested on a local server with bot setup.